### PR TITLE
change attribute name to support latest version of module iam-assumable-role-with-oidc

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -251,7 +251,7 @@ ${var.repo_conf}
     "repoServer.env[0].name"                                               = "AWS_DEFAULT_REGION"
     "repoServer.env[0].value"                                              = data.aws_region.current.name
     "repoServer.serviceAccount.create"                                     = "true"
-    "repoServer.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn" = module.iam_assumable_role_admin.this_iam_role_arn
+    "repoServer.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn" = module.iam_assumable_role_admin.iam_role_arn
     "repoServer.volumes[0].name"                                           = "decryptor"
     "repoServer.volumes[0].configMap.name"                                 = "argocd-decryptor"
     "repoServer.volumes[0].configMap.items[0].key"                         = "decryptor"


### PR DESCRIPTION
Output names in the module iam-assumable-role-with-oidc were change by a recent [commit](https://github.com/terraform-aws-modules/terraform-aws-iam/commit/72c3b055510034958ce3b2516c1bcd1428cc90f2#diff-c86d7b7ae488c287a5dd0c0f799ce7bb76bf33c66a6d30346ede9e35425b273e), this commit changes the attribute names to comply with the latest version of the [iam-assumable-role-with-oidc](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/modules/iam-assumable-role-with-oidc) module