### PR TITLE
Add --insecure-ignore-host-key option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -248,6 +248,7 @@ ${var.repo_conf}
   )
   conf = {
     "server.extraArgs[0]"                = "--insecure"
+    "server.extraArgs[1]"                = "--insecure-ignore-host-key"
     "installCRDs"                        = "false"
     "dex.enabled"                        = "false"
     "server.rbacConfig.policy\\.default" = "role:readonly"


### PR DESCRIPTION
We can't use ssh auth without known_host config, this workaround enables the use of SSH keys without validating host fingerprints. In the future, we can improve this to add real ssh_known_host to the module.
